### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/server/src/main/kotlin/com/cheestree/vetly/config/SecurityConfig.kt
+++ b/src/server/src/main/kotlin/com/cheestree/vetly/config/SecurityConfig.kt
@@ -12,7 +12,6 @@ class SecurityConfig {
     @Profile("dev")
     fun devSecurityFilterChain(http: HttpSecurity): SecurityFilterChain =
         http
-            .csrf { it.disable() }
             .headers { it.frameOptions { it.disable() } }
             .authorizeHttpRequests { it.anyRequest().permitAll() }
             .build()


### PR DESCRIPTION
Potential fix for [https://github.com/cheestree/vetly/security/code-scanning/1](https://github.com/cheestree/vetly/security/code-scanning/1)

The best fix is to remove explicit CSRF disabling in the `dev` security chain so Spring Security’s default CSRF protection remains active. This preserves existing behavior as much as possible while eliminating the vulnerability pattern flagged by CodeQL.

Concretely, in `src/server/src/main/kotlin/com/cheestree/vetly/config/SecurityConfig.kt`, edit `devSecurityFilterChain` and delete the line:
- `.csrf { it.disable() }`

No new methods or imports are required. Spring will apply its default CSRF protection automatically.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
